### PR TITLE
Allow the registry to overwrite an existing object manager

### DIFF
--- a/src/Zf2Doctrine2ManagerRegistryService/Registry/Registry.php
+++ b/src/Zf2Doctrine2ManagerRegistryService/Registry/Registry.php
@@ -56,7 +56,11 @@ class Registry extends AbstractManagerRegistry
      */
     protected function resetService($name)
     {
+        $allowOverwrite = $this->serviceManager->getAllowOverride();
+
+        $this->serviceManager->setAllowOverride(true);
         $this->serviceManager->setService($name, null);
+        $this->serviceManager->setAllowOverride($allowOverwrite);
     }
 
     /**


### PR DESCRIPTION
Allow the registry to overwrite an existing object manager in the ZF service manager when resetting a service.
